### PR TITLE
Fix "goto source" for keywords with parenthesis

### DIFF
--- a/rfassistant/items.py
+++ b/rfassistant/items.py
@@ -8,6 +8,7 @@ import sublime_plugin  # noqa
 # Python imports
 from collections import namedtuple
 import os
+import re
 import tempfile
 import webbrowser
 
@@ -257,7 +258,7 @@ class RFKeyword(object):
         return view.find(r'def\s{0,}%s' % def_keyword, 0, sublime.IGNORECASE)
 
     def _find_keyword_in_resource(self, view):
-        return view.find(r'^%s\s{0,}' % self.name, 0, sublime.IGNORECASE)
+        return view.find(r'^%s\s{0,}' % re.escape(self.name), 0, sublime.IGNORECASE)
 
     @property
     def signature(self):

--- a/rfassistant/test/resources/resource1.txt
+++ b/rfassistant/test/resources/resource1.txt
@@ -33,3 +33,6 @@ Hello1 "${name}" User
 
 Hello2 ${name} User
     Log  ${name}
+
+Example Keyword With Parenthesis (Example)
+    Log    This is Keyword With Parenthesis

--- a/rfassistant/test/tests.txt
+++ b/rfassistant/test/tests.txt
@@ -31,3 +31,6 @@ Verify RFDocs Page Title
     Verify Page Title
     ...  ${RFDOCS_PAGE}
     ...  Robot Framework Documentation
+
+Verify Keyword With Parenthesis
+    Example Keyword With Parenthesis (Example)


### PR DESCRIPTION
Fix "go to source" for keywords with parenthesis.
https://github.com/andriyko/sublime-robot-framework-assistant/issues/30