### PR TITLE
Changed misspelling of robot_frameowrk_extension

### DIFF
--- a/Robot.sublime-settings
+++ b/Robot.sublime-settings
@@ -58,7 +58,7 @@
         syntax highlight.
     */
 
-    "robot_frameowrk_extension": "robot",
+    "robot_framework_extension": "robot",
 
     /*
         Path to Python binary


### PR DESCRIPTION
* The embedded word `frameowrk` (within the key `robot_frameowrk_extension`) appears to be a misspelling of `framework`
* Suggest changing to `robot_framework_extension` :pencil2: