### PR TITLE
Fixes #121 by adding buildin vars also when using index_open_tab

### DIFF
--- a/commands/index_open_tab.py
+++ b/commands/index_open_tab.py
@@ -9,6 +9,7 @@ from ..dataparser.parser_utils.file_formatter import rf_table_name
 from ..dataparser.parser_utils.util import normalise_path
 from ..command_helper.update_current_view_json import update_current_view_index
 from .scan_and_index import index_popen_arg_parser
+from .scan_and_index import add_builtin_vars
 
 
 class IndexOpenTabCommand(sublime_plugin.TextCommand):
@@ -29,6 +30,8 @@ class IndexOpenTabCommand(sublime_plugin.TextCommand):
             sublime.status_message(message)
             return
         db_table_name = self.get_table_name(open_tab)
+        db_dir = get_setting(SettingObject.table_dir)
+        sublime.set_timeout_async(add_builtin_vars(db_dir))
         if db_table_name:
             file_ = open(log_file, 'a')
             sublime.set_timeout_async(

--- a/commands/scan_and_index.py
+++ b/commands/scan_and_index.py
@@ -28,6 +28,21 @@ def index_popen_arg_parser(mode):
     return arg_list
 
 
+def add_builtin_vars(db_path):
+    builtin = 'BuiltIn'
+    table_name = '{0}-{1}.json'.format(
+        builtin, md5(builtin.encode('utf-8')).hexdigest())
+    table_path = path.join(db_path, table_name)
+    f_table = open(table_path, 'r')
+    data = json.load(f_table)
+    f_table.close()
+    builtin_variables = get_setting(SettingObject.builtin_variables)
+    data[DBJsonSetting.variables] = builtin_variables
+    f_table = open(table_path, 'w')
+    json.dump(data, f_table, indent=4)
+    f_table.close()
+
+
 class ScanIndexCommand(sublime_plugin.TextCommand):
 
     def run(self, edit):
@@ -36,7 +51,7 @@ class ScanIndexCommand(sublime_plugin.TextCommand):
         makedirs(path.dirname(log_file), exist_ok=True)
         self.view.run_command('scan')
         file_ = open(log_file, 'a')
-        sublime.set_timeout_async(self.add_builtin_vars(db_dir))
+        sublime.set_timeout_async(add_builtin_vars(db_dir))
         sublime.set_timeout_async(self.run_index(file_), 0)
         file_.close()
         message = update_current_view_index(self.view)
@@ -63,17 +78,3 @@ class ScanIndexCommand(sublime_plugin.TextCommand):
         message = 'Indexing done with rc: {0}'.format(rc)
         sublime.status_message(message)
         print(message)
-
-    def add_builtin_vars(self, db_path):
-        builtin = 'BuiltIn'
-        table_name = '{0}-{1}.json'.format(
-            builtin, md5(builtin.encode('utf-8')).hexdigest())
-        table_path = path.join(db_path, table_name)
-        f_table = open(table_path, 'r')
-        data = json.load(f_table)
-        f_table.close()
-        builtin_variables = get_setting(SettingObject.builtin_variables)
-        data[DBJsonSetting.variables] = builtin_variables
-        f_table = open(table_path, 'w')
-        json.dump(data, f_table, indent=4)
-        f_table.close()


### PR DESCRIPTION
Is user had used only scan and index_open_tab commands, then
the buildin variables where not added correctly to the internal
database. This commit fixes that problem.