### PR TITLE
Edit guide and add [template] snippet

### DIFF
--- a/Context.sublime-menu
+++ b/Context.sublime-menu
@@ -203,6 +203,13 @@
                         }
                     },
                     {
+                        "caption": "[Template]",
+                        "command": "insert_snippet",
+                        "args": {
+                            "name": "Packages/Robot Framework Assistant/snippets/rfde-testdata-table-template.sublime-snippet"
+                        }
+                    },
+                    {
                         "caption": "[Teardown]",
                         "command": "insert_snippet",
                         "args": {

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ and `Test Timeout`.
 and
 [Test Case](http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#test-case-table)
 settings. There currently are available the following snippets::
-`[Arguments]`, `[Documentation]`, `[Return]`, `[Setup]` `[Tags]`, `[Teardown]`
+`[Arguments]`, `[Documentation]`, `[Return]`, `[Setup]`, `[Tags]`, `[Template]`, `[Teardown]`
 and `[Timeout]`.
 * Write `*v` to access `*** Variables ***` snippet.
 

--- a/Robot.sublime-settings
+++ b/Robot.sublime-settings
@@ -71,7 +71,7 @@
         Python binary where the Robot Framework is installed.
 
         In Linux like environments this could be like: /usr/bin/python
-        and in Windows this could be like: C:\Python27\python.exe
+        and in Windows this could be like: C:\\Python27\\python.exe
     */
 
     "path_to_python": "/usr/bin/python",

--- a/snippets/rfde-testdata-table-template.sublime-snippet
+++ b/snippets/rfde-testdata-table-template.sublime-snippet
@@ -1,0 +1,8 @@
+<snippet>
+        <content><![CDATA[[Template]$RF_CELL]]></content>
+        <!-- how to trigger the snippet -->
+        <tabTrigger>:</tabTrigger>
+        <!-- scope to limit where the snippet will trigger -->
+        <scope>source.robot</scope>
+        <description>[Template] setting for keyword and test case table</description>
+</snippet>


### PR DESCRIPTION
- Add double backslash in guide windows write of "path_to_python", like guide of "robot_framework_workspace".

- Add snippets [Template] that use case specifies the template keyword to use. The test itself will contain only data to use as arguments to that keyword. (reference [UserGuide-Template](http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#test-templates))