### PR TITLE
Highlight BDD Prefixes in different color

### DIFF
--- a/Robot.tmLanguage
+++ b/Robot.tmLanguage
@@ -104,7 +104,7 @@
 			<key>comment</key>
 			<string>BDD keywords</string>
 			<key>match</key>
-			<string>^(?i)\s+(Given|When|and|but|Then)</string>
+			<string>(?i)^\s+(Given|When|and|but|Then)</string>
 			<key>name</key>
 			<string>string.robot.bdd</string>
 		</dict>	</array>

--- a/Robot.tmLanguage
+++ b/Robot.tmLanguage
@@ -104,7 +104,7 @@
 			<key>comment</key>
 			<string>BDD keywords</string>
 			<key>match</key>
-			<string>(?i)\s+(Given|When|and|but|Then)</string>
+			<string>^(?i)\s+(Given|When|and|but|Then)</string>
 			<key>name</key>
 			<string>string.robot.bdd</string>
 		</dict>	</array>

--- a/Robot.tmLanguage
+++ b/Robot.tmLanguage
@@ -100,7 +100,14 @@
 			<key>name</key>
 			<string>keyword.control.robot</string>
 		</dict>
-	</array>
+		<dict>
+			<key>comment</key>
+			<string>BDD keywords</string>
+			<key>match</key>
+			<string>(?i)\s+(Given|When|and|but|Then)</string>
+			<key>name</key>
+			<string>string.robot.bdd</string>
+		</dict>	</array>
 	<key>scopeName</key>
 	<string>source.robot</string>
 	<key>uuid</key>


### PR DESCRIPTION
As specified in http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#behavior-driven-style these 5 keywords at beginning are considered prefixes that will still succeed in finding a keyword that does not have the prefix.

I hope I did it correctly, it works nicely for me so far.